### PR TITLE
Don't get the ws datastores in list comprehension

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ cluster = AzureMLCluster(ws,
                          ct, 
                          ws.environments['AzureML-Dask-CPU'], 
                          jupyter=True, 
-                         datastores=[ws.datastores[datastore] for datastore in ws.datastores],
+                         datastores=ws.datastores.values(),
                          scheduler_idle_timeout=7200,
                          admin_username=name,
                          admin_ssh_key='private.key'


### PR DESCRIPTION
I didn't test this but the current code will scale number of network calls linearly with the set of datastores - this will only make one call to get the list